### PR TITLE
EX-5790: Upgrade Resque Dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     resque-prioritize (0.1.0)
-      resque (~> 2.0.0)
+      resque (~> 2.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/resque-prioritize.gemspec
+++ b/resque-prioritize.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # The supported resque version is 2.0, though it needs to be urgently updated due to security reasons.
-  spec.add_dependency 'resque', '~> 2.0.0'
+  spec.add_dependency 'resque', '~> 2.6.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'


### PR DESCRIPTION
Jira: [EX-5790](https://ticketevolution.atlassian.net/browse/EX-5790)

> [!IMPORTANT]
> Toggle to **Squash and Merge** when merging PRs to `staging` branch

## What
This PR updates the `resque` gem to the version on Exchange `2.6.0`

## Testing

I tested this code by running the unit tests locally

## Extras
- [ ] Includes a DB migration
- [ ] After merge, requires local environment changes like running `bin/build`, `.env` changes etc.
- [ ] Includes UI Changes: add screenshots or videos

_(if any are checked, please describe below)_

## PR Code Coverage

- Changeset: XX%
- Overall: XX%

Measure with `bin/test_cov` or some other means. You can find html coverage levels in `coverage/index.html` or in `stdout`.

After a successful test run, you can also see calculated and merged coverage, per branch, on [Grafana](https://grafana.tevo.com/d/6r9OX0y7k/code-coverage?orgId=1)


[EX-5790]: https://ticketevolution.atlassian.net/browse/EX-5790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ