### PR TITLE
Remove deprecated pipeline access

### DIFF
--- a/lib/resque/plugins/prioritize/data_store_extension.rb
+++ b/lib/resque/plugins/prioritize/data_store_extension.rb
@@ -49,9 +49,9 @@ module Resque
           private
 
           def z_push_to_queue(queue, encoded_item, priority)
-            @redis.pipelined do
+            @redis.pipelined do |pipeline|
               watch_queue(queue)
-              @redis.zadd(redis_key_for_queue(queue), priority, with_uuid(encoded_item))
+              pipeline.zadd(redis_key_for_queue(queue), priority, with_uuid(encoded_item))
             end
           end
 

--- a/lib/resque/plugins/prioritize/version.rb
+++ b/lib/resque/plugins/prioritize/version.rb
@@ -3,7 +3,7 @@
 module Resque
   module Plugins
     module Prioritize
-      VERSION = '0.1.0'
+      VERSION = '0.1.1'
     end
   end
 end


### PR DESCRIPTION
This pr addresses the deprecation notice flooding our logs.

```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end
```
